### PR TITLE
Remove deploy from pull requests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,7 @@ trim_trailing_whitespace = false
 [package*.json]
 indent_style = space
 indent_size = 2
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/deploy-to-gh-pages.yaml
+++ b/.github/workflows/deploy-to-gh-pages.yaml
@@ -4,7 +4,7 @@
       push:
         branches:
           - main
-      pull_request:
+      workflow_dispatch:
 
     jobs:
       Deploy:
@@ -33,4 +33,4 @@
 
           - name: Deploy
             uses: actions/deploy-pages@v4
-            
+


### PR DESCRIPTION
Having the deploy run on `pull_request` means there's no way to have an open PR that's a work in progress.