### PR TITLE
Use entity to break static site scraping

### DIFF
--- a/src/_includes/partials/footer.html
+++ b/src/_includes/partials/footer.html
@@ -6,10 +6,8 @@
 		<span class=contact-info>
 			<p class="h4">
 				Contact Us:
-				<a class="email" href="mailto:gig@bytezone.dev">
-					gig@bytezone.dev
-					<iconify-icon icon="bi:send"></iconify-icon>
-				</a>
+				<a class="email" href="mailto:gig&commat;bytezone.dev">gig&commat;bytezone.dev</a>
+				<iconify-icon icon="bi:send"></iconify-icon>
 			</p>
 		</span>
 	</div>


### PR DESCRIPTION
Basically, just replace `@` with the html entity so that really dumb scraping tools don't spam us. May be little payoff, but it's also very low effort.

I also noticed that our anchor tag's underline was continuing into the trailing white space. So I just closed the elements.