### PR TITLE
Fix size restraint units

### DIFF
--- a/src/assets/footer.css
+++ b/src/assets/footer.css
@@ -2,7 +2,6 @@ footer {
 	background-color: var(--black-raisin);
 	color: var(--silver);
 
-	width: 100vw;
 	padding-block: 3rem;
 
 	.container {

--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -30,6 +30,7 @@ body {
     display: grid;
     grid-template-rows: auto 1fr auto;
     min-height: 100vh;
+    min-height: 100svh;
 }
 
 /*****************************************************************************/
@@ -41,7 +42,7 @@ body {
 /*****************************************************************************/
 
 .container {
-    max-width: 1600px;
+    max-width: 100rem;
     margin-inline: auto;
     padding-inline: 1.25rem;
 }
@@ -68,11 +69,11 @@ body {
     justify-content: flex-start;
     --space: 1.5rem;
   }
-  
+
   .stack >  * + * {
     margin-block-start: var(--space, 1.5rem);
   }
-  
+
   .stack:only-child {
     block-size: 100%;
   }


### PR DESCRIPTION
Reference videos:

- [CSS Units](https://youtu.be/IWFqGsXxJ1E?si=yerOl4iIJX8cIQgL) by Kevin Powell
- [Please stop using px...](https://youtu.be/xCSw6bPXZks?si=XkajUsP0rZrZp9D7) by Coder Coder

### TL;DW

1. We don't need the `width` property at all in the footer.
2. Using `100vh` can cause problems on mobile with the dynamic URL bar. Upgrade this by using `100svh`.
3. Defining `max-width` in pixels means the width won't ever change. This can be problem for users with 32px font size (double the normal) in that the content my look squished.